### PR TITLE
Remove unnecessary spawns

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -559,10 +559,12 @@ impl ClientSubset for RwLock<BanksClient> {
                         .collect(),
                     logs: parsed_transaction.logs,
                 })
-                .ok_or(EllipsisClientError::from(anyhow::Error::msg(format!(
-                    "Failed to fetch transaction {}",
-                    signature
-                ))))
+                .ok_or_else(|| {
+                    EllipsisClientError::from(anyhow::Error::msg(format!(
+                        "Failed to fetch transaction {}",
+                        signature
+                    )))
+                })
             })
     }
 


### PR DESCRIPTION
I might be misunderstanding something, but I don't think we need to task spawn here. From the `Arc<RpcClient>` context, we are just calling methods on the internal `RpcClient`.

Please look over carefully @jarry-xiao 