### PR TITLE
Jxiao/yellowstone

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ellipsis-client"
-version = "0.1.17"
+version = "0.2.0"
 edition = "2021"
 description = "Lightweight interface for interacting with the Solana blockchain"
 license = "MIT OR Apache-2.0"
@@ -36,3 +36,6 @@ futures = "0.3.25"
 lazy_static = "1.1.1"
 tarpc = {version = "0.29.0", features = ["full"] }
 tokio-serde = {version = "0.8", features = ["bincode"]}
+yellowstone-grpc-client = "1.1.1+solana.1.15.2"
+yellowstone-grpc-proto = "1.1.0+solana.1.15.2"
+backoff = { version = "0.4.0", features = ["tokio"] }

--- a/src/banks_server.rs
+++ b/src/banks_server.rs
@@ -80,6 +80,8 @@ fn get_parsed_transaction(
             data: ix.data.clone(),
         })
         .collect::<Vec<_>>();
+
+    let signature = tx.signatures[0].to_string();
     let inner_instructions = details
         .inner_instructions
         .unwrap_or_default()
@@ -113,6 +115,7 @@ fn get_parsed_transaction(
         block_time: None,
         instructions: instructions.clone(),
         inner_instructions,
+        signature,
         logs: details.log_messages.unwrap_or_default(),
         is_err: false,
     }

--- a/src/grpc_client.rs
+++ b/src/grpc_client.rs
@@ -1,0 +1,193 @@
+use borsh::BorshDeserialize;
+use itertools::Itertools;
+use solana_sdk::signature::Signature;
+use tokio::sync::mpsc::Sender;
+use yellowstone_grpc_proto::prelude::{Message, TransactionStatusMeta};
+
+use crate::transaction_utils::{ParsedInnerInstruction, ParsedInstruction, ParsedTransaction};
+
+use {
+    backoff::{future::retry, ExponentialBackoff},
+    futures::{sink::SinkExt, stream::StreamExt},
+    solana_sdk::pubkey::Pubkey,
+    std::collections::HashMap,
+    yellowstone_grpc_client::{GeyserGrpcClient, GeyserGrpcClientError},
+    yellowstone_grpc_proto::prelude::{
+        subscribe_update::UpdateOneof, SubscribeRequest, SubscribeRequestFilterTransactions,
+    },
+};
+
+struct YellowstoneTransaction {
+    slot: u64,
+    meta: TransactionStatusMeta,
+    signature: Signature,
+    message: Message,
+}
+
+impl YellowstoneTransaction {
+    pub fn parse_message(
+        &self,
+        loaded_addresses: &[String],
+    ) -> (Vec<String>, Vec<ParsedInstruction>) {
+        let mut keys = self
+            .message
+            .account_keys
+            .iter()
+            .map(|pk| Pubkey::try_from_slice(&pk).unwrap().to_string())
+            .collect_vec();
+        keys.extend_from_slice(loaded_addresses);
+        let instructions = self
+            .message
+            .instructions
+            .iter()
+            .map(|instruction| ParsedInstruction {
+                program_id: keys[instruction.program_id_index as usize].clone(),
+                accounts: instruction
+                    .accounts
+                    .iter()
+                    .map(|i| keys[*i as usize].clone())
+                    .collect(),
+                data: instruction.data.clone(),
+            })
+            .collect_vec();
+        (keys, instructions)
+    }
+
+    pub fn to_parsed_transaction(&self) -> ParsedTransaction {
+        let loaded_addresses = [
+            self.meta
+                .loaded_writable_addresses
+                .iter()
+                .map(|x| Pubkey::try_from_slice(&x).unwrap().to_string())
+                .collect_vec(),
+            self.meta
+                .loaded_readonly_addresses
+                .iter()
+                .map(|x| Pubkey::try_from_slice(&x).unwrap().to_string())
+                .collect_vec(),
+        ]
+        .concat();
+
+        let (keys, instructions) = self.parse_message(&loaded_addresses);
+        let is_err = self.meta.err.is_some();
+        let logs = self.meta.log_messages.clone();
+
+        let inner_instructions = self
+            .meta
+            .inner_instructions
+            .iter()
+            .map(|ii| {
+                ii.instructions
+                    .iter()
+                    .map(|i| ParsedInnerInstruction {
+                        parent_index: ii.index as usize,
+                        instruction: ParsedInstruction {
+                            program_id: keys[i.program_id_index as usize].clone(),
+                            accounts: i
+                                .accounts
+                                .iter()
+                                .map(|i| keys[*i as usize].clone())
+                                .collect(),
+                            data: i.data.clone(),
+                        },
+                    })
+                    .collect::<Vec<ParsedInnerInstruction>>()
+            })
+            .collect::<Vec<Vec<ParsedInnerInstruction>>>();
+
+        ParsedTransaction {
+            slot: self.slot,
+            block_time: None,
+            signature: self.signature.to_string(),
+            instructions,
+            inner_instructions,
+            logs,
+            is_err,
+        }
+    }
+}
+
+pub async fn transaction_subscribe(
+    endpoint: String,
+    x_token: Option<String>,
+    sender: Sender<ParsedTransaction>,
+    accounts_to_include: Vec<Pubkey>,
+    accounts_to_exclude: Vec<Pubkey>,
+) -> anyhow::Result<()> {
+    let mut transactions = HashMap::new();
+    transactions.insert(
+        "client".to_string(),
+        SubscribeRequestFilterTransactions {
+            vote: None,
+            failed: Some(false),
+            signature: None,
+            account_include: accounts_to_include
+                .into_iter()
+                .map(|x| x.to_string())
+                .collect(),
+            account_exclude: accounts_to_exclude
+                .into_iter()
+                .map(|x| x.to_string())
+                .collect(),
+        },
+    );
+
+    // The default exponential backoff strategy intervals:
+    // [500ms, 750ms, 1.125s, 1.6875s, 2.53125s, 3.796875s, 5.6953125s,
+    // 8.5s, 12.8s, 19.2s, 28.8s, 43.2s, 64.8s, 97s, ... ]
+    retry(ExponentialBackoff::default(), move || {
+        let (endpoint, x_token) = (endpoint.clone(), x_token.clone());
+        let transactions = transactions.clone();
+        let sender = sender.clone();
+        async move {
+            println!("Retry to connect to the server");
+            let mut client = GeyserGrpcClient::connect(endpoint, x_token, None)?;
+            let (mut subscribe_tx, mut stream) = client.subscribe().await?;
+            subscribe_tx
+                .send(SubscribeRequest {
+                    slots: HashMap::new(),
+                    accounts: HashMap::new(),
+                    transactions,
+                    blocks: HashMap::new(),
+                    blocks_meta: HashMap::new(),
+                })
+                .await
+                .map_err(GeyserGrpcClientError::SubscribeSendError)?;
+
+            while let Some(message) = stream.next().await {
+                let parsed_tx = message.map(|msg| match msg.update_oneof {
+                    Some(UpdateOneof::Transaction(transaction)) => {
+                        println!(
+                            "new transaction update: filters {:?}, transaction: {:#?}",
+                            msg.filters, transaction
+                        );
+                        let slot = transaction.slot;
+                        let yellowstone_tx = transaction
+                            .transaction
+                            .and_then(|tx| {
+                                Some(YellowstoneTransaction {
+                                    slot,
+                                    meta: tx.meta?,
+                                    signature: Signature::new(&tx.signature),
+                                    message: tx.transaction?.message?,
+                                })
+                            })
+                            .map(|tx| tx.to_parsed_transaction());
+                        yellowstone_tx
+                    }
+                    _ => None,
+                });
+                if let Ok(Some(tx)) = parsed_tx {
+                    if sender.send(tx).await.is_err() {
+                        println!("Failed to send transaction update");
+                    }
+                } else {
+                    println!("Failed to process transaction update");
+                }
+            }
+            Ok(())
+        }
+    })
+    .await
+    .map_err(Into::into)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod ellipsis_client;
 pub mod program_test;
 pub mod programs;
 pub mod transaction_utils;
+pub mod grpc_client;
 
 #[macro_use]
 extern crate solana_bpf_loader_program;


### PR DESCRIPTION
This implements the ability to subscribe to transactions that touch a specific account. Instead of polling for updates, they can now be pushed directly to the downstream process.

One thing to note is that this first pass will only send through transactions that have reached a commitment level of "processed" so these transactions may rollback. We would need to implement a more sophisticated state machine to accommodate a buffering mechanism for sending different commitment levels.