### PR TITLE
feat: add `stack_height` in `ParsedInstruction` and struct `InstructionStack`

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -2,6 +2,11 @@
 resolver = "2"
 members = ["ellipsis-client", "transaction-utils"]
 
+[workspace.package]
+version = "1.2.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
 [profile.release]
 lto = "fat"
 codegen-units = 1
@@ -18,26 +23,15 @@ borsh = "0.10.4"
 bs58 = "0.5.1"
 chrono-humanize = "0.2.3"
 crossbeam-channel = "0.5.14"
+ellipsis-transaction-utils = { path = "transaction-utils" }
+ellipsis-client = { path = "ellipsis-client" }
 futures = "0.3.31"
 itertools = "0.14.0"
 lazy_static = "1.5.0"
 log = "0.4.22"
 serde = "1.0.217"
-solana-banks-client = "~2.1.0"
-solana-bpf-loader-program = "~2.1.0"
-solana-client = "~2.1.0"
-solana-logger = "~2.1.0"
-solana-program = "~2.1.0"
-solana-program-runtime = "~2.1.0"
-solana-runtime = "~2.1.0"
-solana-sdk = "~2.1.0"
-solana-send-transaction-service = "~2.1.0"
-solana-transaction-status = "~2.1.0"
-solana-vote-program = "~2.1.0"
 tarpc = { version = "0.35.0", features = ["full"] }
 thiserror = "2.0.11"
 tokio = { version = "1.43.0", features = ["macros"] }
 tokio-serde = { version = "0.9.0", features = ["bincode"] }
 tracing = { version = "0.1.41", features = ["log"] }
-yellowstone-grpc-client = "4.1.0"
-yellowstone-grpc-proto = "4.1.1"

--- a/crates/ellipsis-client/Cargo.toml
+++ b/crates/ellipsis-client/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "ellipsis-client"
-version = "1.1.0"
-edition = "2021"
 description = "Lightweight interface for interacting with the Solana blockchain"
-license = "MIT OR Apache-2.0"
+version = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
@@ -16,27 +16,27 @@ borsh = { workspace = true }
 bs58 = { workspace = true }
 chrono-humanize = { workspace = true }
 crossbeam-channel = { workspace = true }
-ellipsis-transaction-utils = { version = "1.1.0", path = "../transaction-utils" }
+ellipsis-transaction-utils = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
-solana-banks-client = { workspace = true }
-solana-bpf-loader-program = { workspace = true }
-solana-client = { workspace = true }
-solana-logger = { workspace = true }
-solana-program = { workspace = true }
-solana-program-runtime = { workspace = true }
-solana-runtime = { workspace = true }
-solana-sdk = { workspace = true }
-solana-send-transaction-service = { workspace = true }
-solana-transaction-status = { workspace = true }
-solana-vote-program = { workspace = true }
+solana-banks-client = "~2.1.0"
+solana-bpf-loader-program = "~2.1.0"
+solana-client = "~2.1.0"
+solana-logger = "~2.1.0"
+solana-program = "~2.1.0"
+solana-program-runtime = "~2.1.0"
+solana-runtime = "~2.1.0"
+solana-sdk = "~2.1.0"
+solana-send-transaction-service = "~2.1.0"
+solana-transaction-status = "~2.1.0"
+solana-vote-program = "~2.1.0"
 tarpc = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-serde = { workspace = true }
 tracing = { workspace = true }
-yellowstone-grpc-client = { workspace = true }
-yellowstone-grpc-proto = { workspace = true }
+yellowstone-grpc-client = "4.1.0"
+yellowstone-grpc-proto = "4.1.1"

--- a/crates/ellipsis-client/src/grpc_client.rs
+++ b/crates/ellipsis-client/src/grpc_client.rs
@@ -54,6 +54,7 @@ impl YellowstoneTransaction {
                     .map(|i| keys[*i as usize].clone())
                     .collect(),
                 data: instruction.data.clone(),
+                // transaction.instructions is the outermost instructions, and the stack_height is 1 (from Solana's impl)
                 stack_height: Some(1),
             })
             .collect_vec();

--- a/crates/ellipsis-client/src/grpc_client.rs
+++ b/crates/ellipsis-client/src/grpc_client.rs
@@ -54,6 +54,7 @@ impl YellowstoneTransaction {
                     .map(|i| keys[*i as usize].clone())
                     .collect(),
                 data: instruction.data.clone(),
+                stack_height: Some(1),
             })
             .collect_vec();
         (keys, instructions)
@@ -95,6 +96,7 @@ impl YellowstoneTransaction {
                                 .map(|i| keys[*i as usize].clone())
                                 .collect(),
                             data: i.data.clone(),
+                            stack_height: i.stack_height,
                         },
                     })
                     .collect::<Vec<ParsedInnerInstruction>>()

--- a/crates/transaction-utils/Cargo.toml
+++ b/crates/transaction-utils/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "ellipsis-transaction-utils"
-version = "1.1.0"
-edition = "2021"
 description = "A library for sanely parsing Solana transactions."
-license = "MIT OR Apache-2.0"
+version = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 bs58 = { workspace = true }
 itertools = { workspace = true }
 serde = { workspace = true }
-solana-sdk = { workspace = true }
-solana-transaction-status = { workspace = true }
+solana-sdk = ">=1.16"
+solana-transaction-status = ">=1.16"

--- a/crates/transaction-utils/src/lib.rs
+++ b/crates/transaction-utils/src/lib.rs
@@ -309,6 +309,7 @@ impl InstructionStack {
             .iter()
             .map(|instruction| InstructionStack {
                 instruction: instruction.clone(),
+                // transaction.instructions is the outermost instructions, and the stack_height is 1 (from Solana's impl)
                 stack_height: 1,
                 instructions_in_stack: vec![],
                 flatten_index: 0, // will be updated in the second pass
@@ -322,6 +323,7 @@ impl InstructionStack {
                     &mut instruction_stacks[first_ii.parent_index as usize];
                 parse_inner_instuction_stack(
                     current_instruction_stack,
+                    // Here we start with the outermost *inner* instructions, where the stack_height begins at 2 (cuz it's the second level of instructions)
                     2,
                     0,
                     &ii,

--- a/crates/transaction-utils/src/lib.rs
+++ b/crates/transaction-utils/src/lib.rs
@@ -26,6 +26,7 @@ pub struct ParsedInstruction {
     pub program_id: String,
     pub accounts: Vec<String>,
     pub data: Vec<u8>,
+    pub stack_height: Option<u32>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -46,6 +47,7 @@ pub fn parse_ui_compiled_instruction(
             .map(|i| account_keys[*i as usize].clone())
             .collect(),
         data: bs58::decode(c.data.clone()).into_vec().unwrap(),
+        stack_height: c.stack_height,
     }
 }
 
@@ -60,6 +62,7 @@ pub fn parse_ui_instruction(
                 program_id: pd.program_id.clone(),
                 accounts: pd.accounts.clone(),
                 data: bs58::decode(&pd.data.clone()).into_vec().unwrap(),
+                stack_height: pd.stack_height,
             },
             _ => panic!("Unsupported instruction encoding"),
         },
@@ -78,6 +81,7 @@ pub fn parse_compiled_instruction(
             .map(|i| account_keys[*i as usize].clone())
             .collect(),
         data: instruction.data.clone(),
+        stack_height: Some(1),
     }
 }
 
@@ -287,4 +291,131 @@ pub fn parse_encoded_transaction_with_status_meta(
         is_err,
         fee_payer: keys[0].clone(),
     })
+}
+
+#[derive(Debug, Clone)]
+pub struct InstructionStack {
+    pub instruction: ParsedInstruction,
+    pub stack_height: u32,
+    pub instructions_in_stack: Vec<InstructionStack>,
+    pub flatten_index: usize,
+}
+
+impl InstructionStack {
+    pub fn from_parsed_transaction(tx: &ParsedTransaction) -> Vec<InstructionStack> {
+        // First create stacks with temporary indices
+        let mut instruction_stacks = tx
+            .instructions
+            .iter()
+            .map(|instruction| InstructionStack {
+                instruction: instruction.clone(),
+                stack_height: 1,
+                instructions_in_stack: vec![],
+                flatten_index: 0, // will be updated in the second pass
+            })
+            .collect::<Vec<_>>();
+
+        // build the tree structure
+        for ii in tx.inner_instructions.iter() {
+            if let Some(first_ii) = ii.first() {
+                let current_instruction_stack =
+                    &mut instruction_stacks[first_ii.parent_index as usize];
+                parse_inner_instuction_stack(
+                    current_instruction_stack,
+                    2,
+                    0,
+                    &ii,
+                    &mut 0, // dummy value
+                );
+            }
+        }
+
+        // assign the flatten index by dfs
+        let mut current_index = 0;
+        for stack in instruction_stacks.iter_mut() {
+            assign_indices_dfs(stack, &mut current_index);
+        }
+
+        instruction_stacks
+    }
+}
+
+fn assign_indices_dfs(stack: &mut InstructionStack, current_index: &mut usize) {
+    stack.flatten_index = *current_index;
+    *current_index += 1;
+
+    for inner in stack.instructions_in_stack.iter_mut() {
+        assign_indices_dfs(inner, current_index);
+    }
+}
+
+fn parse_inner_instuction_stack(
+    current_stack: &mut InstructionStack,
+    current_stack_height: u32,
+    inner_inst_cursor: usize,
+    inner_instructions: &Vec<ParsedInnerInstruction>,
+    total_instructions: &mut usize,
+) -> usize {
+    if inner_inst_cursor >= inner_instructions.len() {
+        return inner_inst_cursor;
+    }
+
+    let current_instruction = &inner_instructions[inner_inst_cursor];
+    let stack_height = current_instruction
+        .instruction
+        .stack_height
+        .expect("Inner instruction must have stack height");
+
+    if stack_height < current_stack_height {
+        return inner_inst_cursor;
+    }
+
+    if stack_height == current_stack_height {
+        current_stack.instructions_in_stack.push(InstructionStack {
+            instruction: current_instruction.instruction.clone(),
+            stack_height: current_stack_height,
+            instructions_in_stack: vec![],
+            flatten_index: 0, // dummy value
+        });
+        *total_instructions += 1;
+
+        // Process next instruction at same level
+        return parse_inner_instuction_stack(
+            current_stack,
+            current_stack_height,
+            inner_inst_cursor + 1,
+            inner_instructions,
+            total_instructions,
+        );
+    }
+
+    // case when stack_height > current
+    assert_eq!(
+        stack_height,
+        current_stack_height + 1,
+        "Stack height can only increase by 1"
+    );
+
+    // Get the most recently added instruction stack
+    let last_stack = current_stack
+        .instructions_in_stack
+        .last_mut()
+        .expect("Must have a parent instruction before going deeper");
+
+    // Process instruction at deeper level and continue with remaining instructions
+    let new_cursor = parse_inner_instuction_stack(
+        last_stack,
+        stack_height,
+        inner_inst_cursor,
+        inner_instructions,
+        total_instructions,
+    );
+
+    parse_inner_instuction_stack(
+        current_stack,
+        current_stack_height,
+        new_cursor,
+        inner_instructions,
+        total_instructions,
+    )
 }


### PR DESCRIPTION
- Added  `stack_height` in `ParsedInstruction` and struct `InstructionStack`
- make the `transaction-util` crate as generic as possible w.r.t. the version of solana lib
- bump the version to `1.2.0`