### PR TITLE
chore: upgrade solana to match phoenix perps version

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["ellipsis-client", "transaction-utils"]
 
 [workspace.package]
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
@@ -23,7 +23,7 @@ borsh = "0.10.4"
 bs58 = "0.5.1"
 chrono-humanize = "0.2.3"
 crossbeam-channel = "0.5.14"
-ellipsis-transaction-utils = { path = "transaction-utils", version = "1.2.0" }
+ellipsis-transaction-utils = { path = "transaction-utils", version = "1.3.0" }
 ellipsis-client = { path = "ellipsis-client" }
 futures = "0.3.31"
 itertools = "0.14.0"

--- a/crates/ellipsis-client/Cargo.toml
+++ b/crates/ellipsis-client/Cargo.toml
@@ -22,21 +22,21 @@ itertools = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
-solana-banks-client = "~2.1.0"
-solana-bpf-loader-program = "~2.1.0"
-solana-client = "~2.1.0"
-solana-logger = "~2.1.0"
-solana-program = "~2.1.0"
-solana-program-runtime = "~2.1.0"
-solana-runtime = "~2.1.0"
-solana-sdk = "~2.1.0"
-solana-send-transaction-service = "~2.1.0"
-solana-transaction-status = "~2.1.0"
-solana-vote-program = "~2.1.0"
+solana-banks-client = "~2.2.1"
+solana-bpf-loader-program = "~2.2.1"
+solana-client = "~2.2.1"
+solana-logger = "~2.2.1"
+solana-program = "~2.2.1"
+solana-program-runtime = "~2.2.1"
+solana-runtime = "~2.2.1"
+solana-sdk = "~2.2.1"
+solana-send-transaction-service = "~2.2.1"
+solana-transaction-status = "~2.2.1"
+solana-vote-program = "~2.2.1"
 tarpc = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-serde = { workspace = true }
 tracing = { workspace = true }
-yellowstone-grpc-client = "4.1.0"
-yellowstone-grpc-proto = "4.1.1"
+yellowstone-grpc-client = "6.1.0"
+yellowstone-grpc-proto = "6.1.0"

--- a/crates/transaction-utils/Cargo.toml
+++ b/crates/transaction-utils/Cargo.toml
@@ -9,5 +9,5 @@ license = { workspace = true }
 bs58 = { workspace = true }
 itertools = { workspace = true }
 serde = { workspace = true }
-solana-sdk = ">=1.16, <=2.1"
-solana-transaction-status = ">=1.16, <=2.1"
+solana-sdk = ">=1.16, <=2.2.2"
+solana-transaction-status = ">=1.16, <=2.2.2"


### PR DESCRIPTION
1. Solana crates updated from ~2.1.0 to ~2.2.1: Required to use Solana 2.2.x (currently resolves to 2.2.2)
2. yellowstone-grpc packages updated from 4.x to 6.1.0: Required because version 4.x only supports Solana 2.1, while 6.1.0 supports Solana 2.2
3. transaction-utils constraints updated from <=2.1 to <=2.2.2: Required to allow the Solana 2.2.x versions

